### PR TITLE
Implement Spring Shell (CLI)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.springframework.shell:spring-shell-starter:2.1.3'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/io/pakland/mdas/githubstats/shell/CustomPromptProvider.java
+++ b/src/main/java/io/pakland/mdas/githubstats/shell/CustomPromptProvider.java
@@ -1,0 +1,15 @@
+package io.pakland.mdas.githubstats.shell;
+
+import org.jline.utils.AttributedString;
+import org.springframework.shell.jline.PromptProvider;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomPromptProvider implements PromptProvider {
+
+    @Override
+    public AttributedString getPrompt() {
+        return new AttributedString("# github-stats > ");
+    }
+
+}

--- a/src/main/java/io/pakland/mdas/githubstats/shell/components/CommitComponent.java
+++ b/src/main/java/io/pakland/mdas/githubstats/shell/components/CommitComponent.java
@@ -1,7 +1,34 @@
 package io.pakland.mdas.githubstats.shell.components;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.shell.command.CommandRegistration;
 import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+import org.springframework.shell.standard.ShellOption;
 
 @ShellComponent
 public class CommitComponent {
+
+    public void commits(String user) {
+        System.out.println("commits");
+    }
+
+    @Bean
+    CommandRegistration commitCommandRegistration() {
+        CommitComponent commitComponent = new CommitComponent();
+
+        return CommandRegistration.builder()
+            .command("commits")
+                .description("Number of commits by user")
+            .withTarget()
+                .method(commitComponent, "commits")
+                .and()
+            .withOption()
+                .shortNames('u')
+                .required()
+                .type(String.class)
+                .and()
+            .build();
+    }
+
 }

--- a/src/main/java/io/pakland/mdas/githubstats/shell/components/CommitComponent.java
+++ b/src/main/java/io/pakland/mdas/githubstats/shell/components/CommitComponent.java
@@ -1,0 +1,7 @@
+package io.pakland.mdas.githubstats.shell.components;
+
+import org.springframework.shell.standard.ShellComponent;
+
+@ShellComponent
+public class CommitComponent {
+}

--- a/src/main/java/io/pakland/mdas/githubstats/shell/components/LinesOfCodeComponent.java
+++ b/src/main/java/io/pakland/mdas/githubstats/shell/components/LinesOfCodeComponent.java
@@ -1,0 +1,7 @@
+package io.pakland.mdas.githubstats.shell.components;
+
+import org.springframework.shell.standard.ShellComponent;
+
+@ShellComponent
+public class LinesOfCodeComponent {
+}

--- a/src/main/java/io/pakland/mdas/githubstats/shell/components/LinesOfCodeComponent.java
+++ b/src/main/java/io/pakland/mdas/githubstats/shell/components/LinesOfCodeComponent.java
@@ -1,7 +1,31 @@
 package io.pakland.mdas.githubstats.shell.components;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.shell.command.CommandRegistration;
 import org.springframework.shell.standard.ShellComponent;
 
 @ShellComponent
 public class LinesOfCodeComponent {
+
+    public void locChanges(String user) {
+        System.out.println("locChanges");
+    }
+
+    @Bean
+    CommandRegistration linesOfCodeCommandRegistration() {
+        LinesOfCodeComponent linesOfCodeComponent = new LinesOfCodeComponent();
+
+        return CommandRegistration.builder()
+            .command("locChanges")
+                .description("Lines of code deleted and added")
+            .withTarget()
+                .method(linesOfCodeComponent, "locChanges")
+                .and()
+            .withOption()
+                .shortNames('u')
+                .required()
+                .type(String.class)
+                .and()
+            .build();
+    }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/shell/components/PullRequestComponent.java
+++ b/src/main/java/io/pakland/mdas/githubstats/shell/components/PullRequestComponent.java
@@ -1,0 +1,7 @@
+package io.pakland.mdas.githubstats.shell.components;
+
+import org.springframework.shell.standard.ShellComponent;
+
+@ShellComponent
+public class PullRequestComponent {
+}

--- a/src/main/java/io/pakland/mdas/githubstats/shell/components/PullRequestComponent.java
+++ b/src/main/java/io/pakland/mdas/githubstats/shell/components/PullRequestComponent.java
@@ -1,7 +1,41 @@
 package io.pakland.mdas.githubstats.shell.components;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.shell.command.CommandRegistration;
 import org.springframework.shell.standard.ShellComponent;
 
 @ShellComponent
 public class PullRequestComponent {
+
+    private void prExecuted(String user) {
+        System.out.println("prExecuted");
+    }
+
+    private void prReviewed(String user) {
+        System.out.println("prReviewed");
+    }
+
+    private void prCommentLength(String user) {
+        System.out.println("prCommentLength");
+    }
+
+
+    @Bean
+    CommandRegistration pullRequestCommandRegistration() {
+        PullRequestComponent pullRequestComponent = new PullRequestComponent();
+
+        return CommandRegistration.builder()
+            .command("prExecuted")
+                .description("Number of pull requests executed")
+            .withTarget()
+                .method(pullRequestComponent, "prExecuted")
+                .and()
+            .withOption()
+                .shortNames('u')
+                .required()
+                .type(String.class)
+                .and()
+            .build();
+    }
+
 }


### PR DESCRIPTION
Use Spring Shell to turn the application into a CLI.

This is an initial configuration with a provisional package structure. 

As per the [reference](https://docs.spring.io/spring-shell/docs/2.1.2/site/reference/htmlsingle/), this PR adds ShellComponents and Command Registrations (instead of Annotations which are no longer fully supported).