### PR TITLE
fix: invalid image name for ci

### DIFF
--- a/.github/workflows/jib-container-publish.yml
+++ b/.github/workflows/jib-container-publish.yml
@@ -14,7 +14,7 @@ jobs:
         uses: MathieuSoysal/jib-container-publish.yml@v2.1.3
         with:
           REGISTRY: docker.io
-          IMAGE_NAME: ${{ github.repository }}
+          IMAGE_NAME: githubstats/github-stats
           tag-name: ${{ github.run_number }}
           USERNAME: ${{ secrets.DOCKERHUB_USER }}
           PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Image was pointing at wrong repository in Dockerhub, and so build fails.