### PR TITLE
feat: add `getOrganizationFromTeamName` use case

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/domain/model/Team.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/model/Team.java
@@ -26,6 +26,9 @@ public class Team {
   @Column(name = "member_url")
   private String memberUrl;
 
+  @Column
+  private String name;
+
   @ManyToOne(fetch = FetchType.LAZY)
   private Organization organization;
 
@@ -49,6 +52,14 @@ public class Team {
     orphanRemoval = true
   )
   private List<HistoricQueries> queries = new ArrayList<>();
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return this.name;
+  }
 
   public void addUser(User user) {
     users.add(user);

--- a/src/main/java/io/pakland/mdas/githubstats/domain/ports/TeamRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/ports/TeamRepository.java
@@ -4,10 +4,13 @@ import io.pakland.mdas.githubstats.domain.model.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 /**
  * Add jdoc about the rep
  */
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team,Long> {
+    Optional<Team> findTeamByName(String name);
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamName.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamName.java
@@ -3,9 +3,11 @@ package io.pakland.mdas.githubstats.domain.service;
 import io.pakland.mdas.githubstats.domain.model.Organization;
 import io.pakland.mdas.githubstats.domain.model.Team;
 import io.pakland.mdas.githubstats.domain.ports.TeamRepository;
+import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
+@Service
 public class GetOrganizationFromTeamName {
     private final TeamRepository teamRepository;
 

--- a/src/main/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamName.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamName.java
@@ -1,0 +1,25 @@
+package io.pakland.mdas.githubstats.domain.service;
+
+import io.pakland.mdas.githubstats.domain.model.Organization;
+import io.pakland.mdas.githubstats.domain.model.Team;
+import io.pakland.mdas.githubstats.domain.ports.TeamRepository;
+
+import java.util.Optional;
+
+public class GetOrganizationFromTeamName {
+    private final TeamRepository teamRepository;
+
+    public GetOrganizationFromTeamName(TeamRepository teamRepo) {
+        this.teamRepository = teamRepo;
+    }
+
+    public Organization execute(String teamName) {
+        Optional<Team> maybeTeam = teamRepository.findTeamByName(teamName);
+        if (maybeTeam.isEmpty()) {
+            // TODO: Add exception
+            return null;
+        }
+
+        return maybeTeam.get().getOrganization();
+    }
+}

--- a/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromIdTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromIdTest.java
@@ -13,23 +13,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class GetOrganizationFromIdTest {
     @Test
     public void givenValidId_shouldReturnTrue() {
-        OrganizationRepository orgMock = Mockito.mock(OrganizationRepository.class);
-        Mockito.when(orgMock.findById(Mockito.anyLong())).thenReturn(Optional.of(new Organization()));
+        OrganizationRepository organizationMock = Mockito.mock(OrganizationRepository.class);
+        Mockito.when(organizationMock.findById(Mockito.anyLong())).thenReturn(Optional.of(new Organization()));
 
-        GetOrganizationFromId useCase = new GetOrganizationFromId(orgMock);
-        boolean res = useCase.execute(1L);
+        GetOrganizationFromId useCase = new GetOrganizationFromId(organizationMock);
 
-        assertTrue(res);
+        assertTrue(useCase.execute(1L));
     }
 
     @Test
     public void givenInvalidId_shouldReturnFalse() {
-         OrganizationRepository orgMock = Mockito.mock(OrganizationRepository.class);
-        Mockito.when(orgMock.findById(Mockito.anyLong())).thenReturn(Optional.empty());
+         OrganizationRepository organizationMock = Mockito.mock(OrganizationRepository.class);
+        Mockito.when(organizationMock.findById(Mockito.anyLong())).thenReturn(Optional.empty());
 
-        GetOrganizationFromId useCase = new GetOrganizationFromId(orgMock);
-        boolean res = useCase.execute(1L);
+        GetOrganizationFromId useCase = new GetOrganizationFromId(organizationMock);
 
-        assertFalse(res);
+        assertFalse(useCase.execute(1L));
     }
 }

--- a/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamNameTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamNameTest.java
@@ -14,19 +14,19 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class GetOrganizationFromTeamNameTest {
     @Test
     public void givenTeamName_shouldReturnOrganizationFound() {
-        Organization org = new Organization();
-        org.setId(1L);
-        Team t = new Team();
-        t.setOrganization(org);
+        Organization organization = new Organization();
+        organization.setId(1L);
+        Team team = new Team();
+        team.setOrganization(organization);
 
         TeamRepository teamRepoMock = Mockito.mock(TeamRepository.class);
-        Mockito.when(teamRepoMock.findTeamByName(Mockito.anyString())).thenReturn(Optional.of(t));
+        Mockito.when(teamRepoMock.findTeamByName(Mockito.anyString())).thenReturn(Optional.of(team));
 
         GetOrganizationFromTeamName useCase = new GetOrganizationFromTeamName(teamRepoMock);
-        Organization res = useCase.execute("some team");
+        Organization result = useCase.execute("some team");
 
         Mockito.verify(teamRepoMock, Mockito.times(1)).findTeamByName("some team");
-        assertEquals(res.getId(), org.getId());
+        assertEquals(result.getId(), organization.getId());
     }
 
     // Change for expecting an exception
@@ -36,9 +36,9 @@ public class GetOrganizationFromTeamNameTest {
         Mockito.when(teamRepoMock.findTeamByName(Mockito.anyString())).thenReturn(Optional.empty());
 
         GetOrganizationFromTeamName useCase = new GetOrganizationFromTeamName(teamRepoMock);
-        Organization res = useCase.execute("some team");
+        Organization result = useCase.execute("some team");
 
         Mockito.verify(teamRepoMock, Mockito.times(1)).findTeamByName("some team");
-        assertNull(res);
+        assertNull(result);
     }
 }

--- a/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamNameTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamNameTest.java
@@ -1,0 +1,44 @@
+package io.pakland.mdas.githubstats.domain.service;
+
+import io.pakland.mdas.githubstats.domain.model.Organization;
+import io.pakland.mdas.githubstats.domain.model.Team;
+import io.pakland.mdas.githubstats.domain.ports.TeamRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class GetOrganizationFromTeamNameTest {
+    @Test
+    public void givenTeamName_shouldReturnOrganizationFound() {
+        Organization org = new Organization();
+        org.setId(1L);
+        Team t = new Team();
+        t.setOrganization(org);
+
+        TeamRepository teamRepoMock = Mockito.mock(TeamRepository.class);
+        Mockito.when(teamRepoMock.findTeamByName(Mockito.anyString())).thenReturn(Optional.of(t));
+
+        GetOrganizationFromTeamName useCase = new GetOrganizationFromTeamName(teamRepoMock);
+        Organization res = useCase.execute("some team");
+
+        Mockito.verify(teamRepoMock, Mockito.times(1)).findTeamByName("some team");
+        assertEquals(res.getId(), org.getId());
+    }
+
+    // Change for expecting an exception
+    @Test
+    public void givenTeamName_shouldReturnNull_ifTeamNotFound() {
+        TeamRepository teamRepoMock = Mockito.mock(TeamRepository.class);
+        Mockito.when(teamRepoMock.findTeamByName(Mockito.anyString())).thenReturn(Optional.empty());
+
+        GetOrganizationFromTeamName useCase = new GetOrganizationFromTeamName(teamRepoMock);
+        Organization res = useCase.execute("some team");
+
+        Mockito.verify(teamRepoMock, Mockito.times(1)).findTeamByName("some team");
+        assertNull(res);
+    }
+}


### PR DESCRIPTION
The user will input the name of our organization, not the ID. Therefore, we have to obtain the organization data given a team id.

> Note: Not sure if I have properly used the `return maybeTeam.get().getOrganization();` since the relation is loaded lazily. AFAIK, it should not be an issue.

Closes #41