### PR TITLE
feat: add `AggregateUserReviews` use case

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/AggregateUserReviews.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/AggregateUserReviews.java
@@ -1,0 +1,18 @@
+package io.pakland.mdas.githubstats.application;
+
+import io.pakland.mdas.githubstats.domain.UserReview;
+import io.pakland.mdas.githubstats.domain.UserReviewAggregation;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AggregateUserReviews {
+
+    public AggregateUserReviews() {}
+
+    public UserReviewAggregation execute(List<UserReview> userReviews) {
+        return UserReviewAggregation.aggregate(userReviews);
+    }
+
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/UserReview.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/UserReview.java
@@ -34,14 +34,8 @@ public class UserReview {
   )
   private List<Comment> comments = new ArrayList<>();
 
-  public void addReview(Comment comment) {
-    comments.add(comment);
-    comment.setUserReview(this);
-  }
-
-  public void removeReview(Comment comment) {
-    comments.remove(comment);
-    comment.setUserReview(null);
+  public int sumCommentLength() {
+    return comments.stream().mapToInt(Comment::getLength).sum();
   }
 
   @Override

--- a/src/main/java/io/pakland/mdas/githubstats/domain/UserReviewAggregation.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/UserReviewAggregation.java
@@ -1,0 +1,22 @@
+package io.pakland.mdas.githubstats.domain;
+
+import java.util.List;
+
+public class UserReviewAggregation {
+
+    private final int commentLengthSum;
+
+    private UserReviewAggregation(int commentLengthSum) {
+        this.commentLengthSum = commentLengthSum;
+    }
+
+    public static UserReviewAggregation aggregate(List<UserReview> userReviews) {
+        int commentLengthSum = userReviews.stream().mapToInt(UserReview::sumCommentLength).sum();
+        return new UserReviewAggregation(commentLengthSum);
+    }
+
+    public int getCommentLengthSum() {
+        return commentLengthSum;
+    }
+
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/UserReviewAggregation.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/UserReviewAggregation.java
@@ -4,15 +4,12 @@ import java.util.List;
 
 public class UserReviewAggregation {
 
-    private final int commentLengthSum;
-
-    private UserReviewAggregation(int commentLengthSum) {
-        this.commentLengthSum = commentLengthSum;
-    }
+    private int commentLengthSum;
 
     public static UserReviewAggregation aggregate(List<UserReview> userReviews) {
-        int commentLengthSum = userReviews.stream().mapToInt(UserReview::sumCommentLength).sum();
-        return new UserReviewAggregation(commentLengthSum);
+        UserReviewAggregation userReviewAggregation = new UserReviewAggregation();
+        userReviewAggregation.commentLengthSum = userReviews.stream().mapToInt(UserReview::sumCommentLength).sum();
+        return userReviewAggregation;
     }
 
     public int getCommentLengthSum() {

--- a/src/main/java/io/pakland/mdas/githubstats/domain/repository/UserReviewRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/repository/UserReviewRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
  */
 
 @Repository
-public interface ReviewUserRepository extends JpaRepository<UserReview,Long> {
+public interface UserReviewRepository extends JpaRepository<UserReview,Long> {
 }

--- a/src/test/java/io/pakland/mdas/githubstats/application/AggregateUserReviewsTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/AggregateUserReviewsTest.java
@@ -1,0 +1,41 @@
+package io.pakland.mdas.githubstats.application;
+
+import io.pakland.mdas.githubstats.domain.Comment;
+import io.pakland.mdas.githubstats.domain.UserReview;
+import io.pakland.mdas.githubstats.domain.UserReviewAggregation;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AggregateUserReviewsTest {
+
+    @Test
+    public void aggregatingReviews_shouldGiveValidCommentLengthSum() {
+        int sum = 0;
+        List<UserReview> reviews = new ArrayList<>();
+        Random random = new Random();
+
+        // Generate 10 User reviews, each with random comments
+        for (int i = 0; i < 10; i++) {
+            List<Comment> comments = new ArrayList<>();
+            for (int j = 0; j < 10; j++) {
+                Comment comment = Mockito.mock(Comment.class);
+                int randomLength = random.nextInt(10);
+                comment.setLength(randomLength);
+                comments.add(comment);
+                sum += comment.getLength();  // accumulate comment length to assert at the end
+            }
+            UserReview userReview = Mockito.mock(UserReview.class);
+            userReview.setComments(comments);
+            reviews.add(userReview);
+        }
+
+        int commentLengthSum = UserReviewAggregation.aggregate(reviews).getCommentLengthSum();
+        assertEquals(sum, commentLengthSum);
+    }
+}

--- a/src/test/java/io/pakland/mdas/githubstats/application/GetOrganizationFromIdTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/GetOrganizationFromIdTest.java
@@ -1,6 +1,5 @@
-package io.pakland.mdas.githubstats.domain.service;
+package io.pakland.mdas.githubstats.application;
 
-import io.pakland.mdas.githubstats.application.GetOrganizationFromId;
 import io.pakland.mdas.githubstats.domain.Organization;
 import io.pakland.mdas.githubstats.domain.repository.OrganizationRepository;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/pakland/mdas/githubstats/application/GetOrganizationFromTeamNameTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/GetOrganizationFromTeamNameTest.java
@@ -1,6 +1,5 @@
-package io.pakland.mdas.githubstats.domain.service;
+package io.pakland.mdas.githubstats.application;
 
-import io.pakland.mdas.githubstats.application.GetOrganizationFromTeamName;
 import io.pakland.mdas.githubstats.domain.Organization;
 import io.pakland.mdas.githubstats.domain.Team;
 import io.pakland.mdas.githubstats.domain.repository.TeamRepository;

--- a/src/test/java/io/pakland/mdas/githubstats/application/GetRepositoriesByTeamTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/GetRepositoriesByTeamTest.java
@@ -1,6 +1,5 @@
-package io.pakland.mdas.githubstats.domain.service;
+package io.pakland.mdas.githubstats.application;
 
-import io.pakland.mdas.githubstats.application.GetRepositoriesByTeam;
 import io.pakland.mdas.githubstats.domain.Repository;
 import io.pakland.mdas.githubstats.domain.Team;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/pakland/mdas/githubstats/application/GetTeamsFromOrganizationTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/GetTeamsFromOrganizationTest.java
@@ -1,6 +1,5 @@
-package io.pakland.mdas.githubstats.domain.service;
+package io.pakland.mdas.githubstats.application;
 
-import io.pakland.mdas.githubstats.application.GetTeamsFromOrganization;
 import io.pakland.mdas.githubstats.domain.Organization;
 import io.pakland.mdas.githubstats.domain.Team;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This use case is a bit different from the other use cases as it features the aggregation of entities.

I felt like a class `UserReviewAggregation` was needed to perform the aggregation logic and store the results, and I gave this class a semantic constructor indicating what it was going to do upon instantiation (precisely, aggregating). The use case just runs this aggregation and gets an instance of this class with the results. The logic for each operation is as close to its corresponding entity as possible, with every `UserReview` computing its own line count, and a `UserReviewAggregation` trusting every `UserReview` for running their logic (tell, don't ask).

I don't know if `UserReviewAggregation` really belongs in the model. I guess it might be in the application layer. I certainly don't see it having enough entity to be saved in a table in the database.

All in all, this is kind of a 'sample' aggregation use case because it only runs a single aggregation operation. But if we are OK with this structure we might as well repeat it for the other aggregation use cases.

Closes #45 