### PR TITLE
fix: add missing exceptions to use cases

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/GetOrganizationFromId.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/GetOrganizationFromId.java
@@ -1,7 +1,9 @@
 package io.pakland.mdas.githubstats.application;
 
+import io.pakland.mdas.githubstats.application.exceptions.OrganizationNotFound;
 import io.pakland.mdas.githubstats.domain.Organization;
 import io.pakland.mdas.githubstats.domain.repository.OrganizationRepository;
+import org.aspectj.weaver.ast.Or;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,14 +20,13 @@ public class GetOrganizationFromId {
 
     // For tests sake, we return boolean to know if the code works properly
     @Transactional(readOnly = true)
-    public boolean execute(Long id) {
+    public boolean execute(Long id) throws OrganizationNotFound {
         Optional<Organization> org = organizationRepository.findById(id);
         if (org.isPresent()) {
             return true;
         }
         else {
-            System.out.println("Organization not found");
-            return false;
+            throw new OrganizationNotFound("Organization with id " + id + " not found.");
         }
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/GetOrganizationFromId.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/GetOrganizationFromId.java
@@ -26,7 +26,7 @@ public class GetOrganizationFromId {
             return true;
         }
         else {
-            throw new OrganizationNotFound("Organization with id " + id + " not found.");
+            throw new OrganizationNotFound(id);
         }
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/GetOrganizationFromTeamName.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/GetOrganizationFromTeamName.java
@@ -1,5 +1,6 @@
 package io.pakland.mdas.githubstats.application;
 
+import io.pakland.mdas.githubstats.application.exceptions.TeamNotFound;
 import io.pakland.mdas.githubstats.domain.Organization;
 import io.pakland.mdas.githubstats.domain.Team;
 import io.pakland.mdas.githubstats.domain.repository.TeamRepository;
@@ -15,11 +16,10 @@ public class GetOrganizationFromTeamName {
         this.teamRepository = teamRepo;
     }
 
-    public Organization execute(String teamName) {
+    public Organization execute(String teamName) throws TeamNotFound {
         Optional<Team> maybeTeam = teamRepository.findTeamByName(teamName);
         if (maybeTeam.isEmpty()) {
-            // TODO: Add exception
-            return null;
+            throw new TeamNotFound(teamName);
         }
 
         return maybeTeam.get().getOrganization();

--- a/src/main/java/io/pakland/mdas/githubstats/application/exceptions/OrganizationNotFound.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/exceptions/OrganizationNotFound.java
@@ -1,0 +1,7 @@
+package io.pakland.mdas.githubstats.application.exceptions;
+
+public class OrganizationNotFound extends Exception {
+    public OrganizationNotFound(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/exceptions/OrganizationNotFound.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/exceptions/OrganizationNotFound.java
@@ -1,7 +1,7 @@
 package io.pakland.mdas.githubstats.application.exceptions;
 
 public class OrganizationNotFound extends Exception {
-    public OrganizationNotFound(String message) {
-        super(message);
+    public OrganizationNotFound(Long id) {
+        super("Organization with id: " + id + " not found");
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/exceptions/TeamNotFound.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/exceptions/TeamNotFound.java
@@ -1,0 +1,7 @@
+package io.pakland.mdas.githubstats.application.exceptions;
+
+public class TeamNotFound extends Exception{
+    public TeamNotFound(String team) {
+        super("Team: " + team + ", has no repositories");
+    }
+}

--- a/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromIdTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromIdTest.java
@@ -14,9 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GetOrganizationFromIdTest {
-    @SneakyThrows
     @Test
-    public void givenValidId_shouldReturnTrue() {
+    public void givenValidId_shouldReturnTrue() throws OrganizationNotFound {
         OrganizationRepository organizationMock = Mockito.mock(OrganizationRepository.class);
         Mockito.when(organizationMock.findById(Mockito.anyLong())).thenReturn(Optional.of(new Organization()));
 

--- a/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromIdTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromIdTest.java
@@ -1,17 +1,20 @@
 package io.pakland.mdas.githubstats.domain.service;
 
 import io.pakland.mdas.githubstats.application.GetOrganizationFromId;
+import io.pakland.mdas.githubstats.application.exceptions.OrganizationNotFound;
 import io.pakland.mdas.githubstats.domain.Organization;
 import io.pakland.mdas.githubstats.domain.repository.OrganizationRepository;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GetOrganizationFromIdTest {
+    @SneakyThrows
     @Test
     public void givenValidId_shouldReturnTrue() {
         OrganizationRepository organizationMock = Mockito.mock(OrganizationRepository.class);
@@ -23,12 +26,14 @@ public class GetOrganizationFromIdTest {
     }
 
     @Test
-    public void givenInvalidId_shouldReturnFalse() {
+    public void givenInvalidId_shouldThrowOrganizationNotFound() throws OrganizationNotFound {
          OrganizationRepository organizationMock = Mockito.mock(OrganizationRepository.class);
         Mockito.when(organizationMock.findById(Mockito.anyLong())).thenReturn(Optional.empty());
 
         GetOrganizationFromId useCase = new GetOrganizationFromId(organizationMock);
 
-        assertFalse(useCase.execute(1L));
+        assertThrows(OrganizationNotFound.class, () -> {
+            useCase.execute(1L);
+        });
     }
 }

--- a/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamNameTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamNameTest.java
@@ -14,9 +14,8 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GetOrganizationFromTeamNameTest {
-    @SneakyThrows
     @Test
-    public void givenTeamName_shouldReturnOrganizationFound() {
+    public void givenTeamName_shouldReturnOrganizationFound() throws TeamNotFound {
         Organization organization = new Organization();
         organization.setId(1L);
         Team team = new Team();

--- a/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamNameTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/service/GetOrganizationFromTeamNameTest.java
@@ -1,18 +1,20 @@
 package io.pakland.mdas.githubstats.domain.service;
 
 import io.pakland.mdas.githubstats.application.GetOrganizationFromTeamName;
+import io.pakland.mdas.githubstats.application.exceptions.TeamNotFound;
 import io.pakland.mdas.githubstats.domain.Organization;
 import io.pakland.mdas.githubstats.domain.Team;
 import io.pakland.mdas.githubstats.domain.repository.TeamRepository;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetOrganizationFromTeamNameTest {
+    @SneakyThrows
     @Test
     public void givenTeamName_shouldReturnOrganizationFound() {
         Organization organization = new Organization();
@@ -32,14 +34,15 @@ public class GetOrganizationFromTeamNameTest {
 
     // Change for expecting an exception
     @Test
-    public void givenTeamName_shouldReturnNull_ifTeamNotFound() {
+    public void givenTeamName_shouldThrowTeamNotFound_ifTeamNotFound() {
         TeamRepository teamRepoMock = Mockito.mock(TeamRepository.class);
         Mockito.when(teamRepoMock.findTeamByName(Mockito.anyString())).thenReturn(Optional.empty());
 
         GetOrganizationFromTeamName useCase = new GetOrganizationFromTeamName(teamRepoMock);
-        Organization result = useCase.execute("some team");
+        assertThrows(TeamNotFound.class, () -> {
+            useCase.execute("some team");
+        });
 
         Mockito.verify(teamRepoMock, Mockito.times(1)).findTeamByName("some team");
-        assertNull(result);
     }
 }


### PR DESCRIPTION
As explained in #51, there are use cases that do not have exceptions thrown because we did not know how to set up the folder structure, and, therefore, where to place the different exceptions.

Closes #51 